### PR TITLE
Fetch fallback exchange rates

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,0 +1,33 @@
+name: Fetch exchange rates
+
+on:
+  push:
+    branches: [ "main" ] # On every push to `main`
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1" # Also, regularly at 00:00 on Monday
+
+env:
+  APP_ID: ${{ secrets.APP_ID }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fetch fiat
+        run: curl -X GET "https://openexchangerates.org/api/latest.json?app_id=${{ secrets.APP_ID }}" --output fiat-rates.json # ADJUST PATH HERE
+        
+      - name: Fetch crypto       
+        run: curl -X GET "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd" --output crypto-rates.json # ADJUST PATH HERE
+
+      - name: Push into Git
+        run: |-
+          git config --global user.email "bot@ark-builders.dev"
+          git config --global user.name "ARK Builders Bot"
+          git add fiat-rates.json # ADJUST PATH HERE
+          git add crypto-rates.json # ADJUST PATH HERE
+          git commit -m "Automated update of rates"
+          git push


### PR DESCRIPTION
## 📌 Description  
We want to avoid the "no connection" screen at all cost. That's why same JSON files ([crypto rates](https://github.com/ARK-Builders/cache-exchange-rates/blob/main/crypto-rates.json) and [fiat rates](https://github.com/ARK-Builders/cache-exchange-rates/blob/main/fiat-rates.json)) should be included into the installer itself. The update schedule is not so important here though, even weekly is fine for the start.

When the app fails to refresh rates, it should also check if we've already downloaded the rates at least once. If yes, then take the downloaded exchange rates. If no, take the pre-packaged rates from the fallback JSONs.

Now, it'll be guaranteed that the app works offline under any circumstances. Otherwise, this could become a problem when we remove [our cache repo](https://github.com/ARK-Builders/cache-exchange-rates) and query the APIs directly. There will be much more potential reasons why updating could fail: server unreachable, exceeding quota, not supported in user's region, etc.

## ✅ Changes  
<!-- List the main changes introduced in this PR. -->
- [x] Added GitHub Actions workflow `fetch.yml`

## 🎯 How to Test  
<!-- Steps to verify the implementation. -->
1. Launch the app with clean state (first launch) without internet.
2. Must see outdated exchange rates.
3. Must not see the "no connectivity" splash screen.

## 🆘 TODO
- [ ] Fix paths near the `ADJUST PATH HERE` comments.
- [ ] Remove the `ADJUST PATH HERE` comments.
- [ ] Adjust rates fetch logic in the app to use fallback when the rates have never been fetched yet and there is no internet connection to do it.